### PR TITLE
Make aggressive checks opt-in and group configs under the same hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,16 +95,27 @@ The full command will look something like this
 curl https://raw.githubusercontent.com/synle/js-import-fixer/main/removed-unused-imports.js | node - --filter=App.tsx,Header.tsx
 ```
 
+#### --aggressive
+
+- `--aggressive` : when turned on, the script will be more aggressive when checking for usages of the imports. By default this flag is turned off.
+
+The full command will look something like this
+
+```
+curl https://raw.githubusercontent.com/synle/js-import-fixer/main/removed-unused-imports.js | node - --aggressive
+```
+
 ## Limitations
 
 - At the moment the script will treat individual imports from the same library as a separate import line. In the future, we can have an optional parameter that will group these imports.
 - The script currently only supports `import` syntax, so if you have `require` syntax in your code base, it will skip those. In the future, I plan to combine the two and give users an option to consolidate the import as `import` or require syntax.
 - The code that checks for usage of library uses contains, if your module contains a common name like Box / Button, there might be a false negative, so you might need to remove those manually.
 
-## Future TODO's
+## TODO's
 
 - [x] Potentially provides option to group imports (Using [`--groupImport`](https://github.com/synle/js-import-fixer#--groupimport))
 - [x] Run the script on a files with matching patterns (Using [`--filter`](https://github.com/synle/js-import-fixer#--filter)).
+- [x] Added an option to do aggressive checks for import usages. This is an opt-in feature using [`--agressive`](https://github.com/synle/js-import-fixer#--aggressive)
 - [ ] Publish this package to npm registry
 - [ ] Make this package executable with `npx`
 - [ ] Maybe create a VS Code addon or a separate Electron standalone app that visualize the import transformation and allows user to fine tune the translation one by one.

--- a/removed-unused-imports.js
+++ b/removed-unused-imports.js
@@ -3,16 +3,27 @@ const fs = require("fs");
 const path = require("path");
 const package = require(path.join(process.cwd(), "package.json"));
 
-let groupImport = false;
-let filteredFiles = [];
+const configs = {
+ groupImport: false,
+ filteredFiles: [],
+ agressiveCheck: false,
+}
+
 for (const argv of process.argv) {
   if (argv.includes("--groupImport")) {
-    groupImport = true;
+    configs.groupImport = true;
   }
   if (argv.includes("--filter=")) {
-    filteredFiles = argv.substr(argv.indexOf("=") + 1).split(",");
+    config.filteredFiles = argv.substr(argv.indexOf("=") + 1).split(",");
+  }
+  if (argv.includes("--agressive")) {
+    config.agressiveCheck = true;
   }
 }
+
+console.log('===========================');
+console.log(JSON.stringify(configs, null, 2));
+console.log('===========================');
 
 // get all relevant files
 let files = [];
@@ -51,9 +62,9 @@ while (stack.length > 0) {
 }
 
 // filter out the file
-if (filteredFiles.length > 0) {
+if (configs.filteredFiles.length > 0) {
   files = files.filter((file) =>
-    filteredFiles.some((filteredFile) => file.includes(filteredFile))
+    config.filteredFiles.some((filteredFile) => file.includes(filteredFile))
   );
 }
 
@@ -201,16 +212,22 @@ for (const file of files) {
     for (const aModule of allImportedModules) {
       let isModuleUsed = false;
 
-      if (rawContentWithoutImport.match(`<${aModule}`)) {
-        // used as a react component
-        isModuleUsed = true;
-      }
-      if (
-        rawContentWithoutImport.match(new RegExp("[ ]+" + aModule + "[ ]*")) ||
-        rawContentWithoutImport.match(new RegExp("[ ]*" + aModule + "[ ]+"))
-      ) {
-        // used as a method or an expression
-        isModuleUsed = true;
+      if(configs.agressiveCheck === true){
+        if (rawContentWithoutImport.match(`<${aModule}`)) {
+          // used as a react component
+          isModuleUsed = true;
+        }
+        if (
+          rawContentWithoutImport.match(new RegExp("[ ]+" + aModule + "[. ]*")) ||
+          rawContentWithoutImport.match(new RegExp("[ ]*" + aModule + "[ ]+"))
+        ) {
+          // used as a method or an expression
+          isModuleUsed = true;
+        }
+      } else {
+        if(rawContentWithoutImport.includes(aModule)){
+          isModuleUsed = true;
+        }
       }
 
       if (isModuleUsed) {
@@ -223,8 +240,8 @@ for (const file of files) {
     // generate the new import
     var newImportedContent = [];
 
-    if (groupImport === false) {
-      // here we don't group
+    if (configs.groupImport === false) {
+      // here we don't group, each import is treated as a separate line
       for (const aModule of usedModules) {
         const { type, lib, alias, name } = moduleToLibs[aModule];
         if (type === "module") {

--- a/removed-unused-imports.js
+++ b/removed-unused-imports.js
@@ -4,10 +4,10 @@ const path = require("path");
 const package = require(path.join(process.cwd(), "package.json"));
 
 const configs = {
- groupImport: false,
- filteredFiles: [],
- agressiveCheck: false,
-}
+  groupImport: false,
+  filteredFiles: [],
+  agressiveCheck: false,
+};
 
 for (const argv of process.argv) {
   if (argv.includes("--groupImport")) {
@@ -21,9 +21,9 @@ for (const argv of process.argv) {
   }
 }
 
-console.log('===========================');
+console.log("===========================");
 console.log(JSON.stringify(configs, null, 2));
-console.log('===========================');
+console.log("===========================");
 
 // get all relevant files
 let files = [];
@@ -212,20 +212,22 @@ for (const file of files) {
     for (const aModule of allImportedModules) {
       let isModuleUsed = false;
 
-      if(configs.agressiveCheck === true){
+      if (configs.agressiveCheck === true) {
         if (rawContentWithoutImport.match(`<${aModule}`)) {
           // used as a react component
           isModuleUsed = true;
         }
         if (
-          rawContentWithoutImport.match(new RegExp("[ ]+" + aModule + "[. ]*")) ||
+          rawContentWithoutImport.match(
+            new RegExp("[ ]+" + aModule + "[. ]*")
+          ) ||
           rawContentWithoutImport.match(new RegExp("[ ]*" + aModule + "[ ]+"))
         ) {
           // used as a method or an expression
           isModuleUsed = true;
         }
       } else {
-        if(rawContentWithoutImport.includes(aModule)){
+        if (rawContentWithoutImport.includes(aModule)) {
           isModuleUsed = true;
         }
       }


### PR DESCRIPTION
- [x] Added an option to do aggressive checks for import usages. This is an opt-in feature using [`--agressive`](https://github.com/synle/js-import-fixer#--aggressive)


#### --aggressive

- `--aggressive` : when turned on, the script will be more aggressive when checking for usages of the imports. By default this flag is turned off.

The full command will look something like this

```
curl https://raw.githubusercontent.com/synle/js-import-fixer/main/removed-unused-imports.js | node - --aggressive