### PR TITLE
Remove process.cwd() in path before doing the matching

### DIFF
--- a/src/coreUtils.js
+++ b/src/coreUtils.js
@@ -13,7 +13,7 @@ const coreUtils = {
     if (gitiginorePatterns.length > 0) {
       files = files.filter((file) =>
         gitiginorePatterns.every(
-          (gitiginorePattern) => !file.includes(gitiginorePattern)
+          (gitiginorePattern) => !file.replace(process.cwd(), '').includes(gitiginorePattern)
         )
       );
     }

--- a/src/coreUtils.js
+++ b/src/coreUtils.js
@@ -13,7 +13,8 @@ const coreUtils = {
     if (gitiginorePatterns.length > 0) {
       files = files.filter((file) =>
         gitiginorePatterns.every(
-          (gitiginorePattern) => !file.replace(process.cwd(), '').includes(gitiginorePattern)
+          (gitiginorePattern) =>
+            !file.replace(process.cwd(), "").includes(gitiginorePattern)
         )
       );
     }

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,8 @@ externalPackagesFromJson = [...externalPackagesFromJson].sort();
 // get all relevant files
 let startPath = process.cwd();
 let files = coreUtils.getFilesToProcess(startPath);
+console.log("Total Files Count:", files.length);
+console.log("".padEnd(100, "=").blue());
 
 global.countSkipped = 0;
 global.countProcessed = 0;


### PR DESCRIPTION
Fixes an issue where the gitignore matches the whole full URL, it's best to just compare against the relative paths of found files.