### PR TITLE
Support transforming relative imports into absolute imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,32 @@ The full command will look something like this
 npx import-fixer --aggressive
 ```
 
+
+#### `--transformRelativeImport`
+- `--transformRelativeImport` : when turned on, the script will transform relative imports such as `import IDataAdapter from './IDataAdapter';` in a file to an absolute import such as `import IDataAdapter from 'commons/adapters/IDataAdapter';`
+
+- You can add your own path prefix, by default, we will resolve the full path and add this path prefix to the front of the file.
+
+For these examples, we will consider the original import line as followed
+
+```
+import IDataAdapter from './IDataAdapter';
+```
+
+- The minimal command will be like this, and will convert the import line to `import IDataAdapter from 'commons/adapters/IDataAdapter';`
+
+```
+npx import-fixer --transformRelativeImport
+```
+
+- If you need to pass in custom prefix for path, you can use this command. This will convert the sample import into this with the prefix src/ `import IDataAdapter from 'src/commons/adapters/IDataAdapter';`
+
+```
+npx import-fixer --transformRelativeImport="src/"
+```
+
 ## Limitations
 
-- At the moment the script will treat individual imports from the same library as a separate import line. In the future, we can have an optional parameter that will group these imports.
 - The script currently only supports `import` syntax, so if you have `require` syntax in your code base, it will skip those. In the future, I plan to combine the two and give users an option to consolidate the import as `import` or require syntax.
 - The code that checks for usage of library uses contains, if your module contains a common name like Box / Button, there might be a false negative, so you might need to remove those manually.
 
@@ -127,6 +150,7 @@ npx import-fixer --aggressive
 - [x] Publish this package to npm registry.
 - [x] Make this package executable with `npx` (Using `npx import-fixer`).
 - [x] Respect the files in `.gitignore` and skip those files when running the script.
+- [x] Added an option to transform relative imports into absolute imports (Using [`--transformRelativeImport`](https://synle.github.io/js-import-fixer/#--transformRelativeImport)).
 - [ ] Maybe create a VS Code addon or a separate Electron standalone app that visualize the import transformation and allows user to fine tune the translation one by one.
 
 ## Examples Run

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ Then it will become
 When this flag is turned on, the following import lines
 
 ```js
-import { databaseActionScripts as RmdbDatabaseActionScripts } from 'src/scripts/rmdb';
-import { tableActionScripts as RmdbTableActionScripts } from 'src/scripts/rmdb';
+import { databaseActionScripts as RmdbDatabaseActionScripts } from "src/scripts/rmdb";
+import { tableActionScripts as RmdbTableActionScripts } from "src/scripts/rmdb";
 ```
 
 Will become
@@ -74,7 +74,7 @@ Will become
 import {
   databaseActionScripts as RmdbDatabaseActionScripts,
   tableActionScripts as RmdbTableActionScripts,
-} from 'src/scripts/rmdb';
+} from "src/scripts/rmdb";
 ```
 
 When this flag is turned off (by default), imports will be separated into each individual line. So the following imports
@@ -83,14 +83,14 @@ When this flag is turned off (by default), imports will be separated into each i
 import {
   databaseActionScripts as RmdbDatabaseActionScripts,
   tableActionScripts as RmdbTableActionScripts,
-} from 'src/scripts/rmdb';
+} from "src/scripts/rmdb";
 ```
 
 will become
 
 ```js
-import { databaseActionScripts as RmdbDatabaseActionScripts } from 'src/scripts/rmdb';
-import { tableActionScripts as RmdbTableActionScripts } from 'src/scripts/rmdb';
+import { databaseActionScripts as RmdbDatabaseActionScripts } from "src/scripts/rmdb";
+import { tableActionScripts as RmdbTableActionScripts } from "src/scripts/rmdb";
 ```
 
 #### `--filter`
@@ -113,8 +113,8 @@ The full command will look something like this
 npx import-fixer --aggressive
 ```
 
-
 #### `--transformRelativeImport`
+
 - `--transformRelativeImport` : when turned on, the script will transform relative imports such as `import IDataAdapter from './IDataAdapter';` in a file to an absolute import such as `import IDataAdapter from 'commons/adapters/IDataAdapter';`
 
 - You can add your own path prefix, by default, we will resolve the full path and add this path prefix to the front of the file.
@@ -134,13 +134,10 @@ npx import-fixer --transformRelativeImport="src/"
 ```
 
 Refer to this table for more information.
-| Option                           | Original                                   | After Transformation                                          |
+| Option | Original | After Transformation |
 |---------------------------------|--------------------------------------------|---------------------------------------------------------------|
-| `--transformRelativeImport`       | `import IDataAdapter from './IDataAdapter';` | `import IDataAdapter from 'commons/adapters/IDataAdapter';`     |
+| `--transformRelativeImport` | `import IDataAdapter from './IDataAdapter';` | `import IDataAdapter from 'commons/adapters/IDataAdapter';` |
 | `--transformRelativeImport="src"` | `import IDataAdapter from './IDataAdapter';` | `import IDataAdapter from 'src/commons/adapters/IDataAdapter';` |
-
-
-
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -134,10 +134,10 @@ npx import-fixer --transformRelativeImport="src/"
 ```
 
 Refer to this table for more information.
-| Option                          | Original                                   | After Transformation                                          |
+| Option                           | Original                                   | After Transformation                                          |
 |---------------------------------|--------------------------------------------|---------------------------------------------------------------|
-| --transformRelativeImport       | import IDataAdapter from './IDataAdapter'; | import IDataAdapter from 'commons/adapters/IDataAdapter';     |
-| --transformRelativeImport="src" | import IDataAdapter from './IDataAdapter'; | import IDataAdapter from 'src/commons/adapters/IDataAdapter'; |
+| `--transformRelativeImport`       | `import IDataAdapter from './IDataAdapter';` | `import IDataAdapter from 'commons/adapters/IDataAdapter';`     |
+| `--transformRelativeImport="src"` | `import IDataAdapter from './IDataAdapter';` | `import IDataAdapter from 'src/commons/adapters/IDataAdapter';` |
 
 
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Run this script in your project root.
 
 ### Run it directly
 
-```
+```bash
 npx import-fixer
 ```
 
@@ -40,7 +40,7 @@ It's best to use this script as part of your preformat script in node / frontend
 
 Say you if you have a format script like this
 
-```
+```js
 ...
 "format": "npx prettier --config ./.prettierrc --write **/*.{ts,tsx,js,jsx,scss,yml,html} *.{json,MD}",
 ...
@@ -48,7 +48,7 @@ Say you if you have a format script like this
 
 Then it will become
 
-```
+```js
 ...
 "preformat": "npx import-fixer --groupImport",
 "format": "npx prettier --config ./.prettierrc --write **/*.{ts,tsx,js,jsx,scss,yml,html} *.{json,MD}",
@@ -63,14 +63,14 @@ Then it will become
 
 When this flag is turned on, the following import lines
 
-```
+```js
 import { databaseActionScripts as RmdbDatabaseActionScripts } from 'src/scripts/rmdb';
 import { tableActionScripts as RmdbTableActionScripts } from 'src/scripts/rmdb';
 ```
 
 Will become
 
-```
+```js
 import {
   databaseActionScripts as RmdbDatabaseActionScripts,
   tableActionScripts as RmdbTableActionScripts,
@@ -79,7 +79,7 @@ import {
 
 When this flag is turned off (by default), imports will be separated into each individual line. So the following imports
 
-```
+```js
 import {
   databaseActionScripts as RmdbDatabaseActionScripts,
   tableActionScripts as RmdbTableActionScripts,
@@ -88,7 +88,7 @@ import {
 
 will become
 
-```
+```js
 import { databaseActionScripts as RmdbDatabaseActionScripts } from 'src/scripts/rmdb';
 import { tableActionScripts as RmdbTableActionScripts } from 'src/scripts/rmdb';
 ```
@@ -99,7 +99,7 @@ import { tableActionScripts as RmdbTableActionScripts } from 'src/scripts/rmdb';
 
 The full command will look something like this
 
-```
+```bash
 npx import-fixer --filter=App.tsx,Header.tsx
 ```
 
@@ -109,7 +109,7 @@ npx import-fixer --filter=App.tsx,Header.tsx
 
 The full command will look something like this
 
-```
+```bash
 npx import-fixer --aggressive
 ```
 
@@ -121,21 +121,26 @@ npx import-fixer --aggressive
 
 For these examples, we will consider the original import line as followed
 
-```
-import IDataAdapter from './IDataAdapter';
-```
+- The minimal command will be like this.
 
-- The minimal command will be like this, and will convert the import line to `import IDataAdapter from 'commons/adapters/IDataAdapter';`
-
-```
+```bash
 npx import-fixer --transformRelativeImport
 ```
 
-- If you need to pass in custom prefix for path, you can use this command. This will convert the sample import into this with the prefix src/ `import IDataAdapter from 'src/commons/adapters/IDataAdapter';`
+- You can also pass in the path prefix for the resolved absolute import paths using `--transformRelativeImport="<pathPrefix>"`.
 
-```
+```bash
 npx import-fixer --transformRelativeImport="src/"
 ```
+
+Refer to this table for more information.
+| Option                          | Original                                   | After Transformation                                          |
+|---------------------------------|--------------------------------------------|---------------------------------------------------------------|
+| --transformRelativeImport       | import IDataAdapter from './IDataAdapter'; | import IDataAdapter from 'commons/adapters/IDataAdapter';     |
+| --transformRelativeImport="src" | import IDataAdapter from './IDataAdapter'; | import IDataAdapter from 'src/commons/adapters/IDataAdapter'; |
+
+
+
 
 ## Limitations
 

--- a/__mocks__/nested_dir_a/Calculator.js
+++ b/__mocks__/nested_dir_a/Calculator.js
@@ -1,0 +1,4 @@
+export default const Calculator = {
+  sum: (a,b) => a + b,
+  diff: (a,b) => a - b,
+}

--- a/__mocks__/nested_dir_a/nested_dir_b/ServerApi.js
+++ b/__mocks__/nested_dir_a/nested_dir_b/ServerApi.js
@@ -1,0 +1,3 @@
+export default const ServerApi = {
+  save: (res) => null,
+}

--- a/__mocks__/nested_dir_a/nested_dir_b/sample_3.js
+++ b/__mocks__/nested_dir_a/nested_dir_b/sample_3.js
@@ -1,7 +1,0 @@
-import {sum, diff} from '../Calculator';
-import externalLib1 from 'externalLib1';
-import ServerApi from './ServerApi';
-import {methodLib2, constant2} from "externalLib2";
-
-const res1 = sum(1,2);
-externalLib1();

--- a/__mocks__/nested_dir_a/nested_dir_b/sample_3.js
+++ b/__mocks__/nested_dir_a/nested_dir_b/sample_3.js
@@ -1,0 +1,6 @@
+import {sum, diff} from '../Calculator';
+import externalLib1 from './externalLib1';
+import ServerApi from './ServerApi';
+import {methodLib2, constant2} from "externalLib2";
+
+const res1 = sum(1,2);

--- a/__mocks__/nested_dir_a/nested_dir_b/sample_3.js
+++ b/__mocks__/nested_dir_a/nested_dir_b/sample_3.js
@@ -1,6 +1,7 @@
 import {sum, diff} from '../Calculator';
-import externalLib1 from './externalLib1';
+import externalLib1 from 'externalLib1';
 import ServerApi from './ServerApi';
 import {methodLib2, constant2} from "externalLib2";
 
 const res1 = sum(1,2);
+externalLib1();

--- a/__mocks__/nested_dir_a/nested_dir_b/sample_4.js
+++ b/__mocks__/nested_dir_a/nested_dir_b/sample_4.js
@@ -1,0 +1,7 @@
+import {sum, diff} from '../Calculator';
+import externalLib1 from 'externalLib1';
+import ServerApi from './ServerApi';
+import {methodLib2, constant2} from "externalLib2";
+
+const res1 = sum(1,2);
+externalLib1();

--- a/__mocks__/sample_3.js
+++ b/__mocks__/sample_3.js
@@ -1,5 +1,9 @@
 import externalLib1 from 'externalLib1';
-import {aliasMethodLib1 as myAliasMethod1, unUsedAliasMethod1 as unusedMethod1, constant1} from 'externalLib1';
+import {
+  aliasMethodLib1 as myAliasMethod1,
+  unUsedAliasMethod1 as unusedMethod1,
+  constant1
+} from 'externalLib1';
 import externalLib2 from "externalLib2";
 import {unUsedAliasMethod1 as unusedMethod1} from 'externalLib1';
 import {methodLib1} from 'externalLib1';

--- a/__mocks__/sample_3.js
+++ b/__mocks__/sample_3.js
@@ -1,0 +1,15 @@
+import externalLib1 from 'externalLib1';
+import {aliasMethodLib1 as myAliasMethod1, unUsedAliasMethod1 as unusedMethod1, constant1} from 'externalLib1';
+import externalLib2 from "externalLib2";
+import {unUsedAliasMethod1 as unusedMethod1} from 'externalLib1';
+import {methodLib1} from 'externalLib1';
+import {methodLib2, constant2} from "externalLib2";
+import {aliasMethodLib1 as myAliasMethod1} from 'externalLib1';
+
+var a1 = constant1;
+methodLib1();
+externalLib1();
+myAliasMethod1();
+
+var a2 = constant2;
+var temp2 = externalLib2();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "import-fixer",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "A shell command tool that cleaned up unused imports in a Typescript / Javascript code base.",
   "main": "main.js",
   "bin": {

--- a/src/configs.js
+++ b/src/configs.js
@@ -2,17 +2,21 @@ const configs = {
   groupImport: false,
   filteredFiles: [],
   aggressiveCheck: false,
+  transformRelativeImport: undefined,
 };
 
 for (const argv of process.argv) {
-  if (argv.includes("--groupImport")) {
+  if (argv.includes(`--groupImport`)) {
     configs.groupImport = true;
   }
-  if (argv.includes("--filter=")) {
-    configs.filteredFiles = argv.substr(argv.indexOf("=") + 1).split(",");
+  if (argv.includes(`--filter=`)) {
+    configs.filteredFiles = argv.substr(argv.indexOf(`=`) + 1).split(`,`);
   }
-  if (argv.includes("--aggressive")) {
+  if (argv.includes(`--aggressive`)) {
     configs.aggressiveCheck = true;
+  }
+  if (argv.includes(`--transformRelativeImport=`)) {
+    configs.transformRelativeImport = argv.substr(argv.indexOf(`=`) + 1).replace(/"/g, "");
   }
 }
 

--- a/src/configs.js
+++ b/src/configs.js
@@ -17,6 +17,8 @@ for (const argv of process.argv) {
   }
   if (argv.includes(`--transformRelativeImport=`)) {
     configs.transformRelativeImport = argv.substr(argv.indexOf(`=`) + 1).replace(/"/g, "");
+  } else if (argv.includes(`--transformRelativeImport`)) {
+    configs.transformRelativeImport = '';
   }
 }
 

--- a/src/configs.js
+++ b/src/configs.js
@@ -16,9 +16,11 @@ for (const argv of process.argv) {
     configs.aggressiveCheck = true;
   }
   if (argv.includes(`--transformRelativeImport=`)) {
-    configs.transformRelativeImport = argv.substr(argv.indexOf(`=`) + 1).replace(/"/g, "");
+    configs.transformRelativeImport = argv
+      .substr(argv.indexOf(`=`) + 1)
+      .replace(/"/g, "");
   } else if (argv.includes(`--transformRelativeImport`)) {
-    configs.transformRelativeImport = '';
+    configs.transformRelativeImport = "";
   }
 }
 

--- a/src/coreUtils.js
+++ b/src/coreUtils.js
@@ -147,7 +147,9 @@ const coreUtils = {
             libFullPath = path.resolve(path.dirname(file), lib).replace(process.cwd() + '/', '');
 
             // adding the prefix
-            libFullPath = configs.transformRelativeImport + libFullPath;
+            if(configs.transformRelativeImport){
+              libFullPath = configs.transformRelativeImport + libFullPath;
+            }
           }
         }
 

--- a/src/coreUtils.js
+++ b/src/coreUtils.js
@@ -107,13 +107,22 @@ const coreUtils = {
       let notUsedModules = new Set();
       let usedModules = new Set();
 
-      const REGEX_ABSOLUTE_IMPORTS =
+      const REGEX_ABSOLUTE_ONLY_IMPORTS =
         /import[ ]+[\*{a-zA-Z0-9 ,}\n]+['"][@/a-zA-Z0-9-]+['"][;]*/g;
 
-      let rawContentWithoutImport;
-      rawContentWithoutImport = content.replace(REGEX_ABSOLUTE_IMPORTS, "");
+      const REGEX_INCLUDING_RELATIVE_IMPORTS =
+        /import[ ]+[\*{a-zA-Z0-9 ,}\n]+['"][.@/a-zA-Z0-9-]+['"][;]*/g;
 
-      const importCodeLines = content.match(REGEX_ABSOLUTE_IMPORTS);
+      let rawContentWithoutImport  = content;
+
+      configs.transformRelativeImport = true; // TODO: remove me
+      if(configs.transformRelativeImport === true ){
+        rawContentWithoutImport = rawContentWithoutImport.replace(REGEX_INCLUDING_RELATIVE_IMPORTS,"")
+      } else {
+        rawContentWithoutImport = rawContentWithoutImport.replace(REGEX_ABSOLUTE_ONLY_IMPORTS, "");
+      }
+
+      const importCodeLines = content.match(REGEX_ABSOLUTE_ONLY_IMPORTS);
       if (!importCodeLines || importCodeLines.length === 0) {
         console.log(
           "> Skipped File (No Import):".padStart(17, " ").yellow(),

--- a/src/coreUtils.js
+++ b/src/coreUtils.js
@@ -110,9 +110,6 @@ const coreUtils = {
       const REGEX_INCLUDING_RELATIVE_IMPORTS =
         /import[ ]+[\*{a-zA-Z0-9 ,}\n]+['"][.@/a-zA-Z0-9-]+['"][;]*/g;
 
-
-      configs.transformRelativeImport = ''; // TODO: remove me
-
       let rawContentWithoutImport = content.replace(REGEX_INCLUDING_RELATIVE_IMPORTS,"")
       let importCodeLines = content.match(REGEX_INCLUDING_RELATIVE_IMPORTS);
 

--- a/src/coreUtils.js
+++ b/src/coreUtils.js
@@ -261,22 +261,22 @@ const coreUtils = {
           if (type === "module") {
             if (alias !== name) {
               newImportedContent.push(
-                "import {" + name + " as " + alias + "} from '" + libFullPath + "';"
+                `import { ${name} as ${alias} } from '${libFullPath}';`
               );
             } else {
               newImportedContent.push(
-                "import {" + name + "} from '" + libFullPath + "';"
+                `import { ${ name} } from '${libFullPath}';`
               );
             }
           } else {
             // default
             if (alias === name) {
               newImportedContent.push(
-                "import " + name + " from '" + libFullPath + "';"
+                `import ${name} from '${libFullPath}';`
               );
             } else {
               newImportedContent.push(
-                "import " + name + " as " + alias + " from '" + libFullPath + "';"
+                `import ${name} as ${alias} from '${libFullPath}';`
               );
             }
           }

--- a/src/coreUtils.js
+++ b/src/coreUtils.js
@@ -211,6 +211,7 @@ const coreUtils = {
         }
       });
 
+      // TODO: remove me
       console.log('allImportedModules', allImportedModules);
       console.log('libToModules', libToModules);
       console.log('moduleToLibs', moduleToLibs);
@@ -335,7 +336,6 @@ const coreUtils = {
 
           if (libImportedModules.length > 0) {
             const libFullPath = libToModules[lib][0].libFullPath;
-
             newImportedContent.push(
               `import ${libImportedModules.join(", ")} from '${libFullPath}';`
             );

--- a/src/coreUtils.js
+++ b/src/coreUtils.js
@@ -145,6 +145,9 @@ const coreUtils = {
           // this is a relative imports, then resolve the path if needed
           if(configs.transformRelativeImport !== undefined ){
             libFullPath = path.resolve(path.dirname(file), lib).replace(process.cwd() + '/', '');
+
+            // adding the prefix
+            libFullPath = configs.transformRelativeImport + libFullPath;
           }
         }
 

--- a/src/coreUtils.js
+++ b/src/coreUtils.js
@@ -213,11 +213,6 @@ const coreUtils = {
         }
       });
 
-      // TODO: remove me
-      console.log('allImportedModules', allImportedModules);
-      console.log('libToModules', libToModules);
-      console.log('moduleToLibs', moduleToLibs);
-
       // here we figure out if an import is actually used in the code
       for (const aModule of allImportedModules) {
         let isModuleUsed = false;

--- a/src/coreUtils.js
+++ b/src/coreUtils.js
@@ -110,7 +110,10 @@ const coreUtils = {
       const REGEX_INCLUDING_RELATIVE_IMPORTS =
         /import[ ]+[\*{a-zA-Z0-9 ,}\n]+['"][.@/a-zA-Z0-9-]+['"][;]*/g;
 
-      let rawContentWithoutImport = content.replace(REGEX_INCLUDING_RELATIVE_IMPORTS,"")
+      let rawContentWithoutImport = content.replace(
+        REGEX_INCLUDING_RELATIVE_IMPORTS,
+        ""
+      );
       let importCodeLines = content.match(REGEX_INCLUDING_RELATIVE_IMPORTS);
 
       if (!importCodeLines || importCodeLines.length === 0) {
@@ -131,8 +134,7 @@ const coreUtils = {
           .replace(/from[ ]+['"]/, "")
           .replace(/['"]/, "")
           .replace(/;/, "");
-        libToModules[lib] =
-          libToModules[lib] || [];
+        libToModules[lib] = libToModules[lib] || [];
         let parsed = s
           .replace(/from[ ]+['"][.@/a-zA-Z0-9-]+['"][;]*/, "")
           .replace("import ", "")
@@ -141,13 +143,18 @@ const coreUtils = {
         const moduleSplits = parsed.split("{");
 
         let libFullPath = lib;
-        if(libFullPath.indexOf('./') === 0 || libFullPath.indexOf('../') === 0){
+        if (
+          libFullPath.indexOf("./") === 0 ||
+          libFullPath.indexOf("../") === 0
+        ) {
           // this is a relative imports, then resolve the path if needed
-          if(configs.transformRelativeImport !== undefined ){
-            libFullPath = path.resolve(path.dirname(file), lib).replace(process.cwd() + '/', '');
+          if (configs.transformRelativeImport !== undefined) {
+            libFullPath = path
+              .resolve(path.dirname(file), lib)
+              .replace(process.cwd() + "/", "");
 
             // adding the prefix
-            if(configs.transformRelativeImport){
+            if (configs.transformRelativeImport) {
               libFullPath = configs.transformRelativeImport + libFullPath;
             }
           }
@@ -265,15 +272,13 @@ const coreUtils = {
               );
             } else {
               newImportedContent.push(
-                `import { ${ name} } from '${libFullPath}';`
+                `import { ${name} } from '${libFullPath}';`
               );
             }
           } else {
             // default
             if (alias === name) {
-              newImportedContent.push(
-                `import ${name} from '${libFullPath}';`
-              );
+              newImportedContent.push(`import ${name} from '${libFullPath}';`);
             } else {
               newImportedContent.push(
                 `import ${name} as ${alias} from '${libFullPath}';`

--- a/src/coreUtils.spec.js
+++ b/src/coreUtils.spec.js
@@ -190,6 +190,32 @@ describe("coreUtils.js", () => {
       `);
     });
 
+    test("sample_3.js withGroupImport", async () => {
+      global.countSkipped = 0;
+      global.countProcessed = 0;
+      global.countLibUsedByFile = {};
+
+      configs.groupImport = true;
+
+      const actual = coreUtils.process(
+        fileSample3,
+        mockedExternalPackage,
+        true
+      );
+
+      expect(actual).toMatchInlineSnapshot(`
+        "import externalLib1, { aliasMethodLib1 as myAliasMethod1, constant1, methodLib1 } from 'externalLib1';
+        import externalLib2, { constant2 } from 'externalLib2';
+        var a1 = constant1;
+        methodLib1();
+        externalLib1();
+        myAliasMethod1();
+
+        var a2 = constant2;
+        var temp2 = externalLib2();"
+      `);
+    });
+
     test("sample_4.js with transformRelativeImport", async () => {
       global.countSkipped = 0;
       global.countProcessed = 0;

--- a/src/coreUtils.spec.js
+++ b/src/coreUtils.spec.js
@@ -80,7 +80,11 @@ describe("coreUtils.js", () => {
 
     const fileSample1 = path.join("__mocks__/", "sample_1.js");
     const fileSample2 = path.join("__mocks__/", "sample_2.js");
-    const fileSample3 = path.join("__mocks__/nested_dir_a/nested_dir_b", "sample_3.js");
+    const fileSample3 = path.join("__mocks__/", "sample_3.js");
+    const fileSample4 = path.join(
+      "__mocks__/nested_dir_a/nested_dir_b",
+      "sample_4.js"
+    );
 
     test("sample_1.js simple", async () => {
       global.countSkipped = 0;
@@ -94,20 +98,20 @@ describe("coreUtils.js", () => {
       );
 
       expect(actual).toMatchInlineSnapshot(`
-"import {aliasMethodLib1 as myAliasMethod1} from 'externalLib1';
-import {constant1} from 'externalLib1';
-import {methodLib1} from 'externalLib1';
-import externalLib1 from 'externalLib1';
-import {constant2} from 'externalLib2';
-import externalLib2 from 'externalLib2';
-var a1 = constant1;
-methodLib1();
-externalLib1();
-myAliasMethod1();
+        "import {aliasMethodLib1 as myAliasMethod1} from 'externalLib1';
+        import {constant1} from 'externalLib1';
+        import {methodLib1} from 'externalLib1';
+        import externalLib1 from 'externalLib1';
+        import {constant2} from 'externalLib2';
+        import externalLib2 from 'externalLib2';
+        var a1 = constant1;
+        methodLib1();
+        externalLib1();
+        myAliasMethod1();
 
-var a2 = constant2;
-var temp2 = externalLib2();"
-`);
+        var a2 = constant2;
+        var temp2 = externalLib2();"
+      `);
     });
 
     test("sample_1.js withGroupImport", async () => {
@@ -124,16 +128,16 @@ var temp2 = externalLib2();"
       );
 
       expect(actual).toMatchInlineSnapshot(`
-"import externalLib1, { aliasMethodLib1 as myAliasMethod1, constant1, methodLib1 } from 'externalLib1';
-import externalLib2, { constant2 } from 'externalLib2';
-var a1 = constant1;
-methodLib1();
-externalLib1();
-myAliasMethod1();
+        "import externalLib1, { aliasMethodLib1 as myAliasMethod1, constant1, methodLib1 } from 'externalLib1';
+        import externalLib2, { constant2 } from 'externalLib2';
+        var a1 = constant1;
+        methodLib1();
+        externalLib1();
+        myAliasMethod1();
 
-var a2 = constant2;
-var temp2 = externalLib2();"
-`);
+        var a2 = constant2;
+        var temp2 = externalLib2();"
+      `);
     });
 
     test("sample_2.js simple", async () => {
@@ -148,16 +152,16 @@ var temp2 = externalLib2();"
       );
 
       expect(actual).toMatchInlineSnapshot(`
-"import externalLib1, { aliasMethodLib1 as myAliasMethod1, constant1, methodLib1 } from 'externalLib1';
-import externalLib2, { constant2 } from 'externalLib2';
-var a1 = constant1;
-methodLib1();
-externalLib1();
-myAliasMethod1();
+        "import externalLib1, { aliasMethodLib1 as myAliasMethod1, constant1, methodLib1 } from 'externalLib1';
+        import externalLib2, { constant2 } from 'externalLib2';
+        var a1 = constant1;
+        methodLib1();
+        externalLib1();
+        myAliasMethod1();
 
-var a2 = constant2;
-var temp2 = externalLib2();"
-`);
+        var a2 = constant2;
+        var temp2 = externalLib2();"
+      `);
     });
 
     test("sample_2.js withGroupImport", async () => {
@@ -174,21 +178,19 @@ var temp2 = externalLib2();"
       );
 
       expect(actual).toMatchInlineSnapshot(`
-"import externalLib1, { aliasMethodLib1 as myAliasMethod1, constant1, methodLib1 } from 'externalLib1';
-import externalLib2, { constant2 } from 'externalLib2';
-var a1 = constant1;
-methodLib1();
-externalLib1();
-myAliasMethod1();
+        "import externalLib1, { aliasMethodLib1 as myAliasMethod1, constant1, methodLib1 } from 'externalLib1';
+        import externalLib2, { constant2 } from 'externalLib2';
+        var a1 = constant1;
+        methodLib1();
+        externalLib1();
+        myAliasMethod1();
 
-var a2 = constant2;
-var temp2 = externalLib2();"
-`);
+        var a2 = constant2;
+        var temp2 = externalLib2();"
+      `);
     });
 
-
-
-    test("sample_3.js with simple transformation", async () => {
+    test("sample_4.js with transformRelativeImport", async () => {
       global.countSkipped = 0;
       global.countProcessed = 0;
       global.countLibUsedByFile = {};
@@ -197,29 +199,41 @@ var temp2 = externalLib2();"
       configs.transformRelativeImport = "";
 
       const actual = coreUtils.process(
-        fileSample3,
+        fileSample4,
         mockedExternalPackage,
         true
       );
 
-      expect(actual).toMatchInlineSnapshot();
+      expect(actual).toMatchInlineSnapshot(`
+        "import externalLib1 from 'externalLib1';
+        import { sum } from '__mocks__/nested_dir_a/Calculator';
+
+        const res1 = sum(1,2);
+        externalLib1();"
+      `);
     });
 
-    test("sample_3.js with simple transformation", async () => {
+    test("sample_4.js with transformRelativeImport=somePathPrefix/", async () => {
       global.countSkipped = 0;
       global.countProcessed = 0;
       global.countLibUsedByFile = {};
 
       configs.groupImport = true;
-      configs.transformRelativeImport = "./";
+      configs.transformRelativeImport = "somePathPrefix/";
 
       const actual = coreUtils.process(
-        fileSample3,
+        fileSample4,
         mockedExternalPackage,
         true
       );
 
-      expect(actual).toMatchInlineSnapshot();
+      expect(actual).toMatchInlineSnapshot(`
+        "import externalLib1 from 'externalLib1';
+        import { sum } from 'somePathPrefix/__mocks__/nested_dir_a/Calculator';
+
+        const res1 = sum(1,2);
+        externalLib1();"
+      `);
     });
   });
 });

--- a/src/coreUtils.spec.js
+++ b/src/coreUtils.spec.js
@@ -80,6 +80,7 @@ describe("coreUtils.js", () => {
 
     const fileSample1 = path.join("__mocks__/", "sample_1.js");
     const fileSample2 = path.join("__mocks__/", "sample_2.js");
+    const fileSample3 = path.join("__mocks__/nested_dir_a/nested_dir_b", "sample_3.js");
 
     test("sample_1.js simple", async () => {
       global.countSkipped = 0;
@@ -183,6 +184,42 @@ myAliasMethod1();
 var a2 = constant2;
 var temp2 = externalLib2();"
 `);
+    });
+
+
+
+    test("sample_3.js with simple transformation", async () => {
+      global.countSkipped = 0;
+      global.countProcessed = 0;
+      global.countLibUsedByFile = {};
+
+      configs.groupImport = true;
+      configs.transformRelativeImport = "";
+
+      const actual = coreUtils.process(
+        fileSample3,
+        mockedExternalPackage,
+        true
+      );
+
+      expect(actual).toMatchInlineSnapshot();
+    });
+
+    test("sample_3.js with simple transformation", async () => {
+      global.countSkipped = 0;
+      global.countProcessed = 0;
+      global.countLibUsedByFile = {};
+
+      configs.groupImport = true;
+      configs.transformRelativeImport = "./";
+
+      const actual = coreUtils.process(
+        fileSample3,
+        mockedExternalPackage,
+        true
+      );
+
+      expect(actual).toMatchInlineSnapshot();
     });
   });
 });

--- a/src/coreUtils.spec.js
+++ b/src/coreUtils.spec.js
@@ -98,11 +98,11 @@ describe("coreUtils.js", () => {
       );
 
       expect(actual).toMatchInlineSnapshot(`
-        "import {aliasMethodLib1 as myAliasMethod1} from 'externalLib1';
-        import {constant1} from 'externalLib1';
-        import {methodLib1} from 'externalLib1';
+        "import { aliasMethodLib1 as myAliasMethod1 } from 'externalLib1';
+        import { constant1 } from 'externalLib1';
+        import { methodLib1 } from 'externalLib1';
         import externalLib1 from 'externalLib1';
-        import {constant2} from 'externalLib2';
+        import { constant2 } from 'externalLib2';
         import externalLib2 from 'externalLib2';
         var a1 = constant1;
         methodLib1();


### PR DESCRIPTION
Fixes #31 

- The minimal command will be like this.

```bash
npx import-fixer --transformRelativeImport
```

- You can also pass in the path prefix for the resolved absolute import paths using `--transformRelativeImport="<pathPrefix>"`.

```bash
npx import-fixer --transformRelativeImport="src/"
```

Refer to this table for more information.
| Option                          | Original                                   | After Transformation                                          |
|---------------------------------|--------------------------------------------|---------------------------------------------------------------|
| --transformRelativeImport       | import IDataAdapter from './IDataAdapter'; | import IDataAdapter from 'commons/adapters/IDataAdapter';     |
| --transformRelativeImport="src" | import IDataAdapter from './IDataAdapter'; | import IDataAdapter from 'src/commons/adapters/IDataAdapter'; |