### PR TITLE
An option to output single or double quote in the import lines (Fixes #42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,11 +133,27 @@ npx import-fixer --transformRelativeImport
 npx import-fixer --transformRelativeImport="src/"
 ```
 
-Refer to this table for more information.
+Refer to this table for more information:
 | Option | Original | After Transformation |
 |---------------------------------|--------------------------------------------|---------------------------------------------------------------|
 | `--transformRelativeImport` | `import IDataAdapter from './IDataAdapter';` | `import IDataAdapter from 'commons/adapters/IDataAdapter';` |
 | `--transformRelativeImport="src"` | `import IDataAdapter from './IDataAdapter';` | `import IDataAdapter from 'src/commons/adapters/IDataAdapter';` |
+
+#### `--importQuote`
+
+- `--importQuote`: can be used to set the import line quote. So it's either double quote or single quote. The default behavior is using single quote.
+
+- The minimal command will look like this.
+
+```bash
+npx import-fixer --importQuote=single
+```
+
+Refer to this table for more information:
+| Option                           | Output                                 |
+|----------------------------------|----------------------------------------|
+| `--importQuote=single` (Default) | `import { SqluiCore } from 'typings';` |
+| `--importQuote=double`           | `import { SqluiCore } from "typings";` |
 
 ## Limitations
 
@@ -153,6 +169,7 @@ Refer to this table for more information.
 - [x] Make this package executable with `npx` (Using `npx import-fixer`).
 - [x] Respect the files in `.gitignore` and skip those files when running the script.
 - [x] Added an option to transform relative imports into absolute imports (Using [`--transformRelativeImport`](https://synle.github.io/js-import-fixer/#--transformRelativeImport)).
+- [x] Added an option to control what's the output quote is in the import line. Either single quote or double quote. [`--importQuote`](https://synle.github.io/js-import-fixer/#--importQuote)
 - [ ] Maybe create a VS Code addon or a separate Electron standalone app that visualize the import transformation and allows user to fine tune the translation one by one.
 
 ## Examples Run

--- a/README.md
+++ b/README.md
@@ -150,10 +150,10 @@ npx import-fixer --importQuote=single
 ```
 
 Refer to this table for more information:
-| Option                           | Output                                 |
+| Option | Output |
 |----------------------------------|----------------------------------------|
 | `--importQuote=single` (Default) | `import { SqluiCore } from 'typings';` |
-| `--importQuote=double`           | `import { SqluiCore } from "typings";` |
+| `--importQuote=double` | `import { SqluiCore } from "typings";` |
 
 ## Limitations
 

--- a/src/configs.js
+++ b/src/configs.js
@@ -25,7 +25,8 @@ for (const argv of process.argv) {
     configs.transformRelativeImport = "";
   }
   if (argv.includes(`--importQuote=`)) {
-    configs.importQuote = argv.substr(argv.indexOf(`=`) + 1).trim() !== 'single' ? `"`: `'`;
+    configs.importQuote =
+      argv.substr(argv.indexOf(`=`) + 1).trim() !== "single" ? `"` : `'`;
   }
 }
 

--- a/src/configs.js
+++ b/src/configs.js
@@ -4,6 +4,7 @@ const configs = {
   aggressiveCheck: false,
   transformRelativeImport: undefined,
   isTest: !!process.env.JEST_WORKER_ID,
+  importQuote: `"`,
 };
 
 for (const argv of process.argv) {
@@ -22,6 +23,9 @@ for (const argv of process.argv) {
       .replace(/"/g, "");
   } else if (argv.includes(`--transformRelativeImport`)) {
     configs.transformRelativeImport = "";
+  }
+  if (argv.includes(`--importQuote=`)) {
+    configs.importQuote = argv.substr(argv.indexOf(`=`) + 1).trim() !== 'single' ? `"`: `'`;
   }
 }
 

--- a/src/configs.js
+++ b/src/configs.js
@@ -1,10 +1,10 @@
 const configs = {
+  isTest: !!process.env.JEST_WORKER_ID,
   groupImport: false,
   filteredFiles: [],
   aggressiveCheck: false,
   transformRelativeImport: undefined,
-  isTest: !!process.env.JEST_WORKER_ID,
-  importQuote: `"`,
+  importQuote: `'`,
 };
 
 for (const argv of process.argv) {

--- a/src/coreUtils.js
+++ b/src/coreUtils.js
@@ -397,7 +397,9 @@ const coreUtils = {
       }
 
       newImportedContent = coreUtils.getSortedImports(
-        newImportedContent.map(importedLine => importedLine.replace(/'/g, configs.importQuote)),
+        newImportedContent.map((importedLine) =>
+          importedLine.replace(/'/g, configs.importQuote)
+        ),
         externalPackagesFromJson
       );
 

--- a/src/coreUtils.js
+++ b/src/coreUtils.js
@@ -397,7 +397,7 @@ const coreUtils = {
       }
 
       newImportedContent = coreUtils.getSortedImports(
-        newImportedContent,
+        newImportedContent.map(importedLine => importedLine.replace(/'/g, configs.importQuote)),
         externalPackagesFromJson
       );
 


### PR DESCRIPTION
Fixes #42

#### `--importQuote`

- `--importQuote`: can be used to set the import line quote. So it's either double quote or single quote. The default behavior is using single quote.

- The minimal command will look like this.

```bash
npx import-fixer --importQuote=single
```

Refer to this table for more information:
| Option                           | Output                                 |
|----------------------------------|----------------------------------------|
| `--importQuote=single` (Default) | `import { SqluiCore } from 'typings';` |
| `--importQuote=double`           | `import { SqluiCore } from "typings";` |