### PR TITLE
Added built in node js modules, peerDependencies, optionalDependencies into external deps for sorting...

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,40 @@ let externalPackagesFromJson = [
   ...new Set([
     ...Object.keys(packageJson.devDependencies || {}),
     ...Object.keys(packageJson.dependencies || {}),
+    ...Object.keys(packageJson.peerDependencies  || {}),
+    ...Object.keys(packageJson.optionalDependencies || {}),
+    // these are known built in modules from node
+    // keep it here for sorting
+    ...`
+      assert
+      buffer
+      child_process
+      cluster
+      crypto
+      dgram
+      dns
+      domain
+      events
+      fs
+      http
+      https
+      net
+      os
+      path
+      punycode
+      querystring
+      readline
+      stream
+      string_decoder
+      timers
+      tls
+      tty
+      url
+      util
+      v8
+      vm
+      zlib
+    `.split('\n').map(s => s.trim())
   ]),
 ].sort();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ let externalPackagesFromJson = [
   ...new Set([
     ...Object.keys(packageJson.devDependencies || {}),
     ...Object.keys(packageJson.dependencies || {}),
-    ...Object.keys(packageJson.peerDependencies  || {}),
+    ...Object.keys(packageJson.peerDependencies || {}),
     ...Object.keys(packageJson.optionalDependencies || {}),
     // these are known built in modules from node
     // keep it here for sorting
@@ -48,7 +48,9 @@ let externalPackagesFromJson = [
       v8
       vm
       zlib
-    `.split('\n').map(s => s.trim())
+    `
+      .split('\n')
+      .map((s) => s.trim()),
   ]),
 ].sort();
 


### PR DESCRIPTION
Fixes #69 

- added a list of built-in node modules so we can properly sort library imports as these are not part of external dependencies and also adding optional and peer dependencies into the sorting