### PR TITLE
Wrong sort order when relative modules contains partial matching with built in node modules #74

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,8 @@
+import libraryJson from 'package.json';
 import configs from 'src/utils/configs';
 import coreUtils from 'src/utils/coreUtils';
 import fileUtils from 'src/utils/fileUtils';
 import packageJson from 'src/utils/packageJson';
-import libraryJson from 'package.json';
 console.log('Inputs / Configs '.padEnd(100, '=').blue());
 console.log('PWD:', process.cwd());
 console.log('Version:', libraryJson.version);

--- a/src/utils/coreUtils/coreUtils.spec.ts
+++ b/src/utils/coreUtils/coreUtils.spec.ts
@@ -76,16 +76,21 @@ describe('coreUtils.getSortedImports', () => {
   });
 
   test('example 2 - a complex example', async () => {
-    const mockedExternalPackage = fileUtils.getExternalDependencies([]);
+    const mockedExternalPackage = fileUtils.getExternalDependencies([
+      'externalLib1',
+      'externalLib2',
+    ]);
 
     const actual = coreUtils.getSortedImports(
       [
         `import externalLib1 from 'externalLib1';`,
         `import {methodLib1, constant1, aliasMethodLib1 as myAliasMethod1, unUsedAliasMethod1 as unusedMethod1} from 'externalLib1';`,
         `import path from 'path';`,
+        `import coreUtils from 'src/utils/coreUtils';`,
         `import externalLib2 from 'externalLib2';`,
         `import {methodLib2, constant2} from 'externalLib2';`,
         `import childProcess from 'child_process';`,
+        `import fileUtils from 'src/utils/fileUtils';`,
       ],
       mockedExternalPackage,
     );
@@ -93,11 +98,13 @@ describe('coreUtils.getSortedImports', () => {
     expect(actual).toMatchInlineSnapshot(`
       Array [
         "import childProcess from 'child_process';",
-        "import path from 'path';",
         "import {methodLib1, constant1, aliasMethodLib1 as myAliasMethod1, unUsedAliasMethod1 as unusedMethod1} from 'externalLib1';",
         "import externalLib1 from 'externalLib1';",
         "import {methodLib2, constant2} from 'externalLib2';",
         "import externalLib2 from 'externalLib2';",
+        "import path from 'path';",
+        "import coreUtils from 'src/utils/coreUtils';",
+        "import fileUtils from 'src/utils/fileUtils';",
       ]
     `);
   });
@@ -116,8 +123,14 @@ describe('coreUtils.getSortedImports', () => {
       mockedExternalPackage,
     );
 
-    expect(actual).toMatchInlineSnapshot();
+    expect(actual).toMatchInlineSnapshot(`
+      Array [
+        "import libraryJson from 'package.json';",
+        "import configs from 'src/utils/configs';",
+        "import coreUtils from 'src/utils/coreUtils';",
+        "import fileUtils from 'src/utils/fileUtils';",
+        "import packageJson from 'src/utils/packageJson';",
+      ]
+    `);
   });
-
-
 });

--- a/src/utils/coreUtils/coreUtils.spec.ts
+++ b/src/utils/coreUtils/coreUtils.spec.ts
@@ -27,7 +27,7 @@ describe('coreUtils.getModuleName', () => {
 });
 
 describe('coreUtils.getSortedImports', () => {
-  test('should work for a basic example', async () => {
+  test('example 1 - a basic example', async () => {
     const actual = coreUtils.getSortedImports([
       `import useToaster, { ToasterHandler } from 'src/hooks/useToaster';`,
       `import Box from '@mui/material/Box';`,
@@ -75,7 +75,7 @@ describe('coreUtils.getSortedImports', () => {
     `);
   });
 
-  test('should work for a complex example', async () => {
+  test('example 2 - a complex example', async () => {
     const mockedExternalPackage = fileUtils.getExternalDependencies([]);
 
     const actual = coreUtils.getSortedImports(
@@ -101,4 +101,23 @@ describe('coreUtils.getSortedImports', () => {
       ]
     `);
   });
+
+  test('example 3', async () => {
+    const mockedExternalPackage = fileUtils.getExternalDependencies([]);
+
+    const actual = coreUtils.getSortedImports(
+      [
+        `import configs from 'src/utils/configs';`,
+        `import packageJson from 'src/utils/packageJson';`,
+        `import coreUtils from 'src/utils/coreUtils';`,
+        `import fileUtils from 'src/utils/fileUtils';`,
+        `import libraryJson from 'package.json';`,
+      ],
+      mockedExternalPackage,
+    );
+
+    expect(actual).toMatchInlineSnapshot();
+  });
+
+
 });

--- a/src/utils/coreUtils/index.ts
+++ b/src/utils/coreUtils/index.ts
@@ -85,7 +85,7 @@ const coreUtils = {
     ca = ca.replace(/[ '";]+/g, '');
 
     for (let i = 0; i < externalPackages.length; i++) {
-      if (ca.includes(externalPackages[i])) {
+      if (ca.indexOf(externalPackages[i]) === 0) {
         return i;
       }
     }


### PR DESCRIPTION
Fixes #74

The built in module is so generic it messes up the sort order (aka `utils` will match against `src/utils/myUtils`)
