### PR TITLE
Export this as a library for users to use it programmatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 *.pem
 coverage
-main.js
 node_modules
 package-lock.json
+dist

--- a/.npmignore
+++ b/.npmignore
@@ -11,5 +11,5 @@ package.json
 publishBetaTags.js
 src
 tsconfig.json
-webpack.config.js
+*.config.js
 CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ npm install --save-dev import-fixer
 ```
 
 ```js
-const {fixImport} = require('import-fixer');
+const { fixImport } = require('import-fixer');
 
 const actual = fixImport(
   'abc.js',
@@ -199,13 +199,11 @@ myAliasMethod1();
 
 var a2 = constant2;
 var temp2 = externalLib2();
-  `
+  `,
 );
 
 console.log(actual);
-
 ```
-
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -170,6 +170,43 @@ Refer to this table for more information:
 
 By default, we don't parse legacy import lines (with `require`), ie. `const fs = require('fs')`. To enable this feature you need to pass in `--parseLegacyImports` parameter.
 
+## How to use this as a library?
+
+The following code shows how to use this library programmatically.
+
+```bash
+npm install --save-dev import-fixer
+```
+
+```js
+const {fixImport} = require('import-fixer');
+
+const actual = fixImport(
+  'abc.js',
+  `
+import externalLib1 from 'externalLib1';
+import {methodLib1} from 'externalLib1';
+import {constant1, aliasMethodLib1 as myAliasMethod1, unUsedAliasMethod1 as unusedMethod1} from 'externalLib1';
+import {aliasMethodLib1 as myAliasMethod1} from 'externalLib1';
+import {unUsedAliasMethod1 as unusedMethod1} from 'externalLib1';
+import externalLib2 from "externalLib2";
+import {methodLib2, constant2} from "externalLib2";
+
+var a1 = constant1;
+methodLib1();
+externalLib1();
+myAliasMethod1();
+
+var a2 = constant2;
+var temp2 = externalLib2();
+  `
+);
+
+console.log(actual);
+
+```
+
+
 ## Limitations
 
 - The script currently only supports `import` syntax, so if you have `require` syntax in your code base, it will skip those. In the future, I plan to combine the two and give users an option to consolidate the import as `import` or require syntax.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "import-fixer",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "A shell command tool that cleaned up unused imports in a Typescript / Javascript code base.",
   "main": "./dist/library.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -2,16 +2,20 @@
   "name": "import-fixer",
   "version": "0.7.0",
   "description": "A shell command tool that cleaned up unused imports in a Typescript / Javascript code base.",
-  "main": "main.js",
+  "main": "./dist/library.js",
   "bin": {
-    "import-fixer": "main.js"
+    "import-fixer": "./dist/bin.js"
   },
   "scripts": {
+    "clean": "rm -rf main.js bin.js dist coverage",
     "prefix-import": "npm run build",
     "fix-import": "node main.js  --groupImport --transformRelativeImport --ignored=__mocks__,.github",
     "preformat": "npm run fix-import",
     "format": "npx prettier --config ./.prettierrc --write **/*.{ts,js,json,md}",
-    "build": "npx webpack --config webpack.config.js",
+    "prebuild": "npm run clean",
+    "build": "npm run build-binary && npm run build-library",
+    "build-binary": "npx webpack --config webpack-bin.config.js",
+    "build-library": "npx webpack --config webpack-library.config.js",
     "test": "npx jest"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "import-fixer": "./dist/bin.js"
   },
   "scripts": {
-    "clean": "rm -rf main.js bin.js dist coverage",
+    "clean": "rm -rf dist coverage",
     "prefix-import": "npm run build",
-    "fix-import": "node main.js  --groupImport --transformRelativeImport --ignored=__mocks__,.github",
+    "fix-import": "node dist/bin.js  --groupImport --transformRelativeImport --ignored=__mocks__,.github",
     "preformat": "npm run fix-import",
     "format": "npx prettier --config ./.prettierrc --write **/*.{ts,js,json,md}",
     "prebuild": "npm run clean",

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -3,8 +3,7 @@ import configs from 'src/utils/configs';
 import coreUtils from 'src/utils/coreUtils';
 import fileUtils from 'src/utils/fileUtils';
 import packageJson from 'src/utils/packageJson';
-
-function _runAsBinaryScript(){
+function _runAsBinaryScript() {
   console.log('Inputs / Configs '.padEnd(100, '=').blue());
   console.log('PWD:', process.cwd());
   console.log('Version:', libraryJson.version);
@@ -36,17 +35,17 @@ function _runAsBinaryScript(){
       fileUtils.read(file).trim(),
       externalPackagesFromJson,
       false,
-      countLibUsedByFile
+      countLibUsedByFile,
     );
 
     if (output.error) {
-      console.log('> Error:'.padStart(17, ' ').yellow(), file, output.message);
+      console.log('> Error:'.padEnd(10, ' ').red(), file.yellow(), output.message);
       countSkipped++;
     } else {
       console.log(
-        '> Success:'.padStart(17, ' ').green(),
-        file,
-        output.unusedLibCount + ' Removed',
+        '> Success:'.padEnd(10, ' ').green(),
+        file.yellow(),
+        output.unusedLibs.length + ' Removed',
       );
       countProcessed++;
     }

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -4,7 +4,7 @@ import coreUtils from 'src/utils/coreUtils';
 import fileUtils from 'src/utils/fileUtils';
 import packageJson from 'src/utils/packageJson';
 
-function _runAsScript(){
+function _runAsBinaryScript(){
   console.log('Inputs / Configs '.padEnd(100, '=').blue());
   console.log('PWD:', process.cwd());
   console.log('Version:', libraryJson.version);
@@ -71,27 +71,4 @@ function _runAsScript(){
   process.exit();
 }
 
-let shouldRunAsScript = false;
-if (require.main === module) {
-  // script is called directly (npx run ...)
-  shouldRunAsScript = true;
-  _runAsScript();
-} else {
-  // script is required as a module
-  shouldRunAsScript = false;
-}
-
-export default (file: string, content: string, externalPackages: string[] = [], libUsageStats = {}) => {
-  if(shouldRunAsScript){
-    throw 'Not supported for running as script (npx)';
-    return;
-  }
-
-  return coreUtils.process(
-    file,
-    content,
-    externalPackages,
-    false,
-    libUsageStats = {}
-  );
-}
+_runAsBinaryScript();

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -43,6 +43,11 @@ function _runAsBinaryScript(){
       console.log('> Error:'.padStart(17, ' ').yellow(), file, output.message);
       countSkipped++;
     } else {
+      console.log(
+        '> Success:'.padStart(17, ' ').green(),
+        file,
+        output.unusedLibCount + ' Removed',
+      );
       countProcessed++;
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,61 +3,95 @@ import configs from 'src/utils/configs';
 import coreUtils from 'src/utils/coreUtils';
 import fileUtils from 'src/utils/fileUtils';
 import packageJson from 'src/utils/packageJson';
-console.log('Inputs / Configs '.padEnd(100, '=').blue());
-console.log('PWD:', process.cwd());
-console.log('Version:', libraryJson.version);
-console.log(''.padEnd(100, '=').blue());
-console.log(JSON.stringify(configs, null, 2));
-console.log(''.padEnd(100, '=').blue());
 
-// external packages from json
-const externalPackagesFromJson = fileUtils.getExternalDependencies([
-  ...Object.keys(packageJson.devDependencies || {}),
-  ...Object.keys(packageJson.dependencies || {}),
-  ...Object.keys(packageJson.peerDependencies || {}),
-  ...Object.keys(packageJson.optionalDependencies || {}),
-]);
+function _runAsScript(){
+  console.log('Inputs / Configs '.padEnd(100, '=').blue());
+  console.log('PWD:', process.cwd());
+  console.log('Version:', libraryJson.version);
+  console.log(''.padEnd(100, '=').blue());
+  console.log(JSON.stringify(configs, null, 2));
+  console.log(''.padEnd(100, '=').blue());
 
-// get all relevant files
-let startPath = process.cwd();
-let files = coreUtils.getFilesToProcess(startPath);
-console.log('Total Files Count:', files.length);
-console.log(''.padEnd(100, '=').blue());
+  // external packages from json
+  const externalPackagesFromJson = fileUtils.getExternalDependencies([
+    ...Object.keys(packageJson.devDependencies || {}),
+    ...Object.keys(packageJson.dependencies || {}),
+    ...Object.keys(packageJson.peerDependencies || {}),
+    ...Object.keys(packageJson.optionalDependencies || {}),
+  ]);
 
-let countSkipped = 0;
-let countProcessed = 0;
-let countLibUsedByFile: Record<string, number> = {};
+  // get all relevant files
+  let startPath = process.cwd();
+  let files = coreUtils.getFilesToProcess(startPath);
+  console.log('Total Files Count:', files.length);
+  console.log(''.padEnd(100, '=').blue());
 
-for (const file of files) {
-  const output = coreUtils.process(file, externalPackagesFromJson, false, countLibUsedByFile);
+  let countSkipped = 0;
+  let countProcessed = 0;
+  let countLibUsedByFile: Record<string, number> = {};
 
-  if (output.error) {
-    console.log('> Error:'.padStart(17, ' ').yellow(), file, output.message);
-    countSkipped++;
-  } else {
-    countProcessed++;
+  for (const file of files) {
+    const output = coreUtils.process(
+      file,
+      fileUtils.read(file).trim(),
+      externalPackagesFromJson,
+      false,
+      countLibUsedByFile
+    );
+
+    if (output.error) {
+      console.log('> Error:'.padStart(17, ' ').yellow(), file, output.message);
+      countSkipped++;
+    } else {
+      countProcessed++;
+    }
   }
+
+  let countLibUsedByFileList: [string, number][] = [];
+  for (const lib of Object.keys(countLibUsedByFile)) {
+    countLibUsedByFileList.push([lib, countLibUsedByFile[lib]]);
+  }
+  countLibUsedByFileList = countLibUsedByFileList.sort((a, b) => {
+    let res = b[1] - a[1];
+    if (res !== 0) {
+      return res;
+    }
+    return a[0].localeCompare(b[0]);
+  });
+
+  console.log('Import Stats '.padEnd(100, '=').blue());
+  console.log(countLibUsedByFileList.map((list) => list.join(': ')).join('\n'));
+  console.log(''.padEnd(100, '=').blue());
+
+  console.log('Total Skipped / Processed '.padEnd(100, '=').blue());
+  console.log('countSkipped:', countSkipped);
+  console.log('countProcessed:', countProcessed);
+  console.log(''.padEnd(100, '=').blue());
+
+  process.exit();
 }
 
-let countLibUsedByFileList: [string, number][] = [];
-for (const lib of Object.keys(countLibUsedByFile)) {
-  countLibUsedByFileList.push([lib, countLibUsedByFile[lib]]);
+let shouldRunAsScript = false;
+if (require.main === module) {
+  // script is called directly (npx run ...)
+  shouldRunAsScript = true;
+  _runAsScript();
+} else {
+  // script is required as a module
+  shouldRunAsScript = false;
 }
-countLibUsedByFileList = countLibUsedByFileList.sort((a, b) => {
-  let res = b[1] - a[1];
-  if (res !== 0) {
-    return res;
+
+export default (file: string, content: string, externalPackages: string[] = [], libUsageStats = {}) => {
+  if(shouldRunAsScript){
+    throw 'Not supported for running as script (npx)';
+    return;
   }
-  return a[0].localeCompare(b[0]);
-});
 
-console.log('Import Stats '.padEnd(100, '=').blue());
-console.log(countLibUsedByFileList.map((list) => list.join(': ')).join('\n'));
-console.log(''.padEnd(100, '=').blue());
-
-console.log('Total Skipped / Processed '.padEnd(100, '=').blue());
-console.log('countSkipped:', countSkipped);
-console.log('countProcessed:', countProcessed);
-console.log(''.padEnd(100, '=').blue());
-
-process.exit();
+  return coreUtils.process(
+    file,
+    content,
+    externalPackages,
+    false,
+    libUsageStats = {}
+  );
+}

--- a/src/library.ts
+++ b/src/library.ts
@@ -1,20 +1,15 @@
-import libraryJson from 'package.json';
-import configs from 'src/utils/configs';
 import coreUtils from 'src/utils/coreUtils';
-import fileUtils from 'src/utils/fileUtils';
-import packageJson from 'src/utils/packageJson';
 
-const fixImport = (file: string, content: string, externalPackages: string[] = [], libUsageStats = {}) => {
-  return coreUtils.process(
-    file,
-    content,
-    externalPackages,
-    false,
-    libUsageStats = {}
-  );
-}
+const fixImport = (
+  file: string,
+  content: string,
+  externalPackages: string[] = [],
+  libUsageStats = {},
+) => {
+  return coreUtils.process(file, content, externalPackages, false, (libUsageStats = {}));
+};
 
 module.exports = {
   fixImport,
   default: fixImport,
-}
+};

--- a/src/library.ts
+++ b/src/library.ts
@@ -14,7 +14,6 @@ const fixImport = (file: string, content: string, externalPackages: string[] = [
   );
 }
 
-
 module.exports = {
   fixImport,
   default: fixImport,

--- a/src/library.ts
+++ b/src/library.ts
@@ -1,0 +1,21 @@
+import libraryJson from 'package.json';
+import configs from 'src/utils/configs';
+import coreUtils from 'src/utils/coreUtils';
+import fileUtils from 'src/utils/fileUtils';
+import packageJson from 'src/utils/packageJson';
+
+const fixImport = (file: string, content: string, externalPackages: string[] = [], libUsageStats = {}) => {
+  return coreUtils.process(
+    file,
+    content,
+    externalPackages,
+    false,
+    libUsageStats = {}
+  );
+}
+
+
+module.exports = {
+  fixImport,
+  default: fixImport,
+}

--- a/src/utils/coreUtils/coreUtils.process.spec.ts
+++ b/src/utils/coreUtils/coreUtils.process.spec.ts
@@ -18,6 +18,9 @@ describe('coreUtils.process', () => {
   const fileSample5 = path.join('__mocks__/', 'sample_5.js');
   const fileSample6 = path.join('__mocks__/', 'sample_6.js');
 
+
+  const _process = (file) => coreUtils.process(file, fileUtils.read(file).trim(), mockedExternalPackage, true);
+
   afterEach(() => {
     for (const key of Object.keys(clonedConfigs)) {
       configs[key] = clonedConfigs[key];
@@ -25,14 +28,14 @@ describe('coreUtils.process', () => {
   });
 
   test('sample_empty.js simple', async () => {
-    const actual = coreUtils.process(fileSampleEmpty, mockedExternalPackage, true);
+    const actual = _process(fileSampleEmpty);
 
     expect(actual.error).toBe(true);
     expect(actual.message).toMatchInlineSnapshot(`"File Content is empty"`);
   });
 
   test('sample_0.js simple', async () => {
-    const actual = coreUtils.process(fileSample0, mockedExternalPackage, true);
+    const actual = _process(fileSample0);
 
     expect(actual.error).toBe(true);
     expect(actual.message).toMatchInlineSnapshot(`"No Import of any kind was found"`);
@@ -41,7 +44,7 @@ describe('coreUtils.process', () => {
   test('sample_1.js simple', async () => {
     // configs.groupImport = false; (implied)
 
-    const actual = coreUtils.process(fileSample1, mockedExternalPackage, true);
+    const actual = _process(fileSample1);
 
     expect(actual.error).toBe(false);
 
@@ -72,7 +75,7 @@ describe('coreUtils.process', () => {
   test('sample_1.js withGroupImport', async () => {
     configs.groupImport = true;
 
-    const actual = coreUtils.process(fileSample1, mockedExternalPackage, true);
+    const actual = _process(fileSample1);
 
     expect(actual.error).toBe(false);
 
@@ -99,7 +102,7 @@ describe('coreUtils.process', () => {
   test('sample_2.js simple', async () => {
     // configs.groupImport = false; (implied)
 
-    const actual = coreUtils.process(fileSample2, mockedExternalPackage, true);
+    const actual = _process(fileSample2);
 
     expect(actual.error).toBe(false);
 
@@ -130,7 +133,7 @@ describe('coreUtils.process', () => {
   test('sample_2.js withGroupImport', async () => {
     configs.groupImport = true;
 
-    const actual = coreUtils.process(fileSample2, mockedExternalPackage, true);
+    const actual = _process(fileSample2);
 
     expect(actual.error).toBe(false);
 
@@ -157,7 +160,7 @@ describe('coreUtils.process', () => {
   test('sample_3.js withGroupImport', async () => {
     configs.groupImport = true;
 
-    const actual = coreUtils.process(fileSample3, mockedExternalPackage, true);
+    const actual = _process(fileSample3);
 
     expect(actual.error).toBe(false);
 
@@ -185,7 +188,7 @@ describe('coreUtils.process', () => {
     configs.groupImport = true;
     configs.transformRelativeImport = '';
 
-    const actual = coreUtils.process(fileSample4, mockedExternalPackage, true);
+    const actual = _process(fileSample4);
 
     expect(actual.error).toBe(false);
 
@@ -209,7 +212,7 @@ describe('coreUtils.process', () => {
     configs.groupImport = true;
     configs.transformRelativeImport = 'somePathPrefix/';
 
-    const actual = coreUtils.process(fileSample4, mockedExternalPackage, true);
+    const actual = _process(fileSample4);
 
     expect(actual.error).toBe(false);
 
@@ -230,7 +233,7 @@ describe('coreUtils.process', () => {
   });
 
   test('sample_5.js simple', async () => {
-    const actual = coreUtils.process(fileSample5, mockedExternalPackage, true);
+    const actual = _process(fileSample5);
 
     expect(actual.error).toBe(false);
 
@@ -263,7 +266,7 @@ describe('coreUtils.process', () => {
   test('sample_5.js withGroupImport', async () => {
     configs.groupImport = true;
 
-    const actual = coreUtils.process(fileSample5, mockedExternalPackage, true);
+    const actual = _process(fileSample5);
 
     expect(actual.error).toBe(false);
 
@@ -294,7 +297,7 @@ describe('coreUtils.process', () => {
     // configs.groupImport = false; (implied)
     configs.parseLegacyImports = true;
 
-    const actual = coreUtils.process(fileSample6, mockedExternalPackage, true);
+    const actual = _process(fileSample6);
 
     expect(actual.error).toBe(false);
 
@@ -336,7 +339,7 @@ describe('coreUtils.process', () => {
     configs.groupImport = true;
     configs.parseLegacyImports = true;
 
-    const actual = coreUtils.process(fileSample6, mockedExternalPackage, true);
+    const actual = _process(fileSample6);
 
     expect(actual.error).toBe(false);
 
@@ -373,7 +376,7 @@ describe('coreUtils.process', () => {
     configs.groupImport = true;
     // configs.parseLegacyImports = false; (implied)
 
-    const actual = coreUtils.process(fileSample6, mockedExternalPackage, true);
+    const actual = _process(fileSample6);
 
     expect(actual.error).toBe(false);
 

--- a/src/utils/coreUtils/coreUtils.process.spec.ts
+++ b/src/utils/coreUtils/coreUtils.process.spec.ts
@@ -18,8 +18,8 @@ describe('coreUtils.process', () => {
   const fileSample5 = path.join('__mocks__/', 'sample_5.js');
   const fileSample6 = path.join('__mocks__/', 'sample_6.js');
 
-
-  const _process = (file) => coreUtils.process(file, fileUtils.read(file).trim(), mockedExternalPackage, true);
+  const _process = (file) =>
+    coreUtils.process(file, fileUtils.read(file).trim(), mockedExternalPackage, true);
 
   afterEach(() => {
     for (const key of Object.keys(clonedConfigs)) {
@@ -47,6 +47,13 @@ describe('coreUtils.process', () => {
     const actual = _process(fileSample1);
 
     expect(actual.error).toBe(false);
+
+    expect(actual.unusedLibs).toMatchInlineSnapshot(`
+      Array [
+        "unusedMethod1",
+        "methodLib2",
+      ]
+    `);
 
     expect(actual.libUsageStats).toMatchInlineSnapshot(`
         Object {
@@ -79,6 +86,13 @@ describe('coreUtils.process', () => {
 
     expect(actual.error).toBe(false);
 
+    expect(actual.unusedLibs).toMatchInlineSnapshot(`
+      Array [
+        "unusedMethod1",
+        "methodLib2",
+      ]
+    `);
+
     expect(actual.libUsageStats).toMatchInlineSnapshot(`
         Object {
           "externalLib1": 1,
@@ -105,6 +119,13 @@ describe('coreUtils.process', () => {
     const actual = _process(fileSample2);
 
     expect(actual.error).toBe(false);
+
+    expect(actual.unusedLibs).toMatchInlineSnapshot(`
+      Array [
+        "unusedMethod1",
+        "methodLib2",
+      ]
+    `);
 
     expect(actual.libUsageStats).toMatchInlineSnapshot(`
         Object {
@@ -137,6 +158,13 @@ describe('coreUtils.process', () => {
 
     expect(actual.error).toBe(false);
 
+    expect(actual.unusedLibs).toMatchInlineSnapshot(`
+      Array [
+        "unusedMethod1",
+        "methodLib2",
+      ]
+    `);
+
     expect(actual.libUsageStats).toMatchInlineSnapshot(`
         Object {
           "externalLib1": 1,
@@ -163,6 +191,13 @@ describe('coreUtils.process', () => {
     const actual = _process(fileSample3);
 
     expect(actual.error).toBe(false);
+
+    expect(actual.unusedLibs).toMatchInlineSnapshot(`
+      Array [
+        "unusedMethod1",
+        "methodLib2",
+      ]
+    `);
 
     expect(actual.libUsageStats).toMatchInlineSnapshot(`
         Object {
@@ -192,6 +227,15 @@ describe('coreUtils.process', () => {
 
     expect(actual.error).toBe(false);
 
+    expect(actual.unusedLibs).toMatchInlineSnapshot(`
+      Array [
+        "diff",
+        "ServerApi",
+        "methodLib2",
+        "constant2",
+      ]
+    `);
+
     expect(actual.libUsageStats).toMatchInlineSnapshot(`
         Object {
           "../Calculator": 1,
@@ -216,6 +260,15 @@ describe('coreUtils.process', () => {
 
     expect(actual.error).toBe(false);
 
+    expect(actual.unusedLibs).toMatchInlineSnapshot(`
+      Array [
+        "diff",
+        "ServerApi",
+        "methodLib2",
+        "constant2",
+      ]
+    `);
+
     expect(actual.libUsageStats).toMatchInlineSnapshot(`
         Object {
           "../Calculator": 1,
@@ -236,6 +289,14 @@ describe('coreUtils.process', () => {
     const actual = _process(fileSample5);
 
     expect(actual.error).toBe(false);
+
+    expect(actual.unusedLibs).toMatchInlineSnapshot(`
+      Array [
+        "methodLib2",
+        "unusedMethod1",
+        "externalLib2",
+      ]
+    `);
 
     expect(actual.libUsageStats).toMatchInlineSnapshot(`
       Object {
@@ -270,6 +331,14 @@ describe('coreUtils.process', () => {
 
     expect(actual.error).toBe(false);
 
+    expect(actual.unusedLibs).toMatchInlineSnapshot(`
+      Array [
+        "methodLib2",
+        "unusedMethod1",
+        "externalLib2",
+      ]
+    `);
+
     expect(actual.libUsageStats).toMatchInlineSnapshot(`
       Object {
         "child_process": 1,
@@ -300,6 +369,13 @@ describe('coreUtils.process', () => {
     const actual = _process(fileSample6);
 
     expect(actual.error).toBe(false);
+
+    expect(actual.unusedLibs).toMatchInlineSnapshot(`
+      Array [
+        "unusedMethod1",
+        "externalLib2",
+      ]
+    `);
 
     expect(actual.libUsageStats).toMatchInlineSnapshot(`
       Object {
@@ -343,6 +419,13 @@ describe('coreUtils.process', () => {
 
     expect(actual.error).toBe(false);
 
+    expect(actual.unusedLibs).toMatchInlineSnapshot(`
+      Array [
+        "unusedMethod1",
+        "externalLib2",
+      ]
+    `);
+
     expect(actual.libUsageStats).toMatchInlineSnapshot(`
       Object {
         "child_process": 1,
@@ -379,6 +462,13 @@ describe('coreUtils.process', () => {
     const actual = _process(fileSample6);
 
     expect(actual.error).toBe(false);
+
+    expect(actual.unusedLibs).toMatchInlineSnapshot(`
+      Array [
+        "unusedMethod1",
+        "externalLib2",
+      ]
+    `);
 
     expect(actual.libUsageStats).toMatchInlineSnapshot(`
       Object {

--- a/src/utils/coreUtils/index.ts
+++ b/src/utils/coreUtils/index.ts
@@ -59,7 +59,7 @@ type MainProcessOutput =
       error: false;
       output: string;
       libUsageStats: LibUsageStatMap;
-      unusedLibCount: number;
+      unusedLibs: string[];
     };
 
 /**
@@ -448,7 +448,7 @@ const coreUtils = {
       let importedModules: ImportedModules = new Set();
 
       // set of used modules
-      let notUsedModules = new Set<string>();
+      let unusedLibs = new Set<string>();
       let usedModules = new Set<string>();
 
       let rawContentWithoutImport = content.replace(REGEX_IMPORT_ES6_FULL_LINE, '');
@@ -512,7 +512,7 @@ const coreUtils = {
         if (isModuleUsed) {
           usedModules.add(aModule);
         } else {
-          notUsedModules.add(aModule);
+          unusedLibs.add(aModule);
         }
       }
 
@@ -555,7 +555,7 @@ const coreUtils = {
         error: false,
         output: finalContent,
         libUsageStats,
-        unusedLibCount: notUsedModules.size,
+        unusedLibs: [...unusedLibs],
       };
     } catch (err) {
       return {

--- a/src/utils/coreUtils/index.ts
+++ b/src/utils/coreUtils/index.ts
@@ -429,15 +429,13 @@ const coreUtils = {
   },
   process: (
     file: string,
+    content: string,
     externalPackagesFromJson: string[],
     dontWriteToOutputFile = false,
     libUsageStats: LibUsageStatMap = {},
   ): MainProcessOutput => {
     try {
-      const content = fileUtils.read(file).trim();
-
       if (!content) {
-        console.log('> Skipped File (Empty Content):'.padStart(17, ' ').yellow(), file);
         return {
           error: true,
           message: 'File Content is empty',
@@ -481,7 +479,6 @@ const coreUtils = {
       }
 
       if (!importedModules || importedModules.size === 0) {
-        console.log('> Skipped File (No Import):'.padStart(17, ' ').yellow(), file);
         return {
           error: true,
           message: 'No Import of any kind was found',
@@ -565,11 +562,9 @@ const coreUtils = {
         libUsageStats,
       };
     } catch (err) {
-      console.log('[Error] process failed for file: '.red(), file, err);
-
       return {
         error: true,
-        message: 'Uncaught Error: ' + JSON.stringify(err),
+        message: 'Uncaught Error: Failed to Process - ' + JSON.stringify(err),
       };
     }
   },

--- a/src/utils/coreUtils/index.ts
+++ b/src/utils/coreUtils/index.ts
@@ -59,6 +59,7 @@ type MainProcessOutput =
       error: false;
       output: string;
       libUsageStats: LibUsageStatMap;
+      unusedLibCount: number;
     };
 
 /**
@@ -528,12 +529,6 @@ const coreUtils = {
         externalPackagesFromJson,
       );
 
-      console.log(
-        '> Repaired File:'.padStart(17, ' ').green(),
-        file,
-        notUsedModules.size + ' Removed',
-      );
-
       let finalContent =
         newImportedContent.join('\n').trim() +
         '\n' +
@@ -560,6 +555,7 @@ const coreUtils = {
         error: false,
         output: finalContent,
         libUsageStats,
+        unusedLibCount: notUsedModules.size,
       };
     } catch (err) {
       return {

--- a/webpack-bin.config.js
+++ b/webpack-bin.config.js
@@ -1,0 +1,37 @@
+const path = require('path');
+const webpack = require('webpack');
+
+module.exports = {
+  mode: 'production',
+  target: ['node'],
+  entry: './src/bin.ts',
+  output: {
+    filename: './dist/bin.js',
+    libraryTarget: 'this',
+    path: path.resolve(__dirname, './'),
+  },
+  plugins: [new webpack.BannerPlugin({ banner: '#! /usr/bin/env node', raw: true })],
+  module: {
+    rules: [
+      {
+        test: /\.(js|jsx|ts|tsx)$/,
+        use: [
+          {
+            loader: 'ts-loader',
+            options: {
+              configFile: 'tsconfig.json',
+            },
+          },
+        ],
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js', '.jsx'],
+    alias: {
+      src: path.resolve(__dirname, 'src'),
+      'package.json': path.resolve(__dirname, 'package.json'),
+    },
+  },
+};

--- a/webpack-library.config.js
+++ b/webpack-library.config.js
@@ -4,13 +4,12 @@ const webpack = require('webpack');
 module.exports = {
   mode: 'production',
   target: ['node'],
-  entry: './src/index.ts',
+  entry: './src/library.ts',
   output: {
-    filename: 'main.js',
+    filename: './dist/library.js',
     libraryTarget: 'this',
     path: path.resolve(__dirname, './'),
   },
-  plugins: [new webpack.BannerPlugin({ banner: '#! /usr/bin/env node', raw: true })],
   module: {
     rules: [
       {


### PR DESCRIPTION
- Fixes #83
- Bundle this as a npx script as well as a library
- Cleaned up the main method do display any logs
- Assert unused library in test

#### `--parseLegacyImports`

By default, we don't parse legacy import lines (with `require`), ie. `const fs = require('fs')`. To enable this feature you need to pass in `--parseLegacyImports` parameter.

## How to use this as a library?

The following code shows how to use this library programmatically.

```bash
npm install --save-dev import-fixer
```

```js
const {fixImport} = require('import-fixer');

const actual = fixImport(
  'abc.js',
  `
import externalLib1 from 'externalLib1';
import {methodLib1} from 'externalLib1';
import {constant1, aliasMethodLib1 as myAliasMethod1, unUsedAliasMethod1 as unusedMethod1} from 'externalLib1';
import {aliasMethodLib1 as myAliasMethod1} from 'externalLib1';
import {unUsedAliasMethod1 as unusedMethod1} from 'externalLib1';
import externalLib2 from "externalLib2";
import {methodLib2, constant2} from "externalLib2";

var a1 = constant1;
methodLib1();
externalLib1();
myAliasMethod1();

var a2 = constant2;
var temp2 = externalLib2();
  `
);

console.log(actual);

```