### PR TITLE
feat: forward dontWriteToOutputFile

### DIFF
--- a/src/library.ts
+++ b/src/library.ts
@@ -4,9 +4,10 @@ const fixImport = (
   file: string,
   content: string,
   externalPackages: string[] = [],
+  dontWriteToOutputFile = false,
   libUsageStats = {},
 ) => {
-  return coreUtils.process(file, content, externalPackages, false, (libUsageStats = {}));
+  return coreUtils.process(file, content, externalPackages, dontWriteToOutputFile, (libUsageStats = {}));
 };
 
 module.exports = {


### PR DESCRIPTION
When using `fixImport` programmatically, I want the ability to not write the file to the filesystem